### PR TITLE
Add subtract command to calculator

### DIFF
--- a/calc.py
+++ b/calc.py
@@ -7,17 +7,24 @@ def add(a, b):
     return a + b
 
 
+def subtract(a, b):
+    return a - b
+
+
 def main():
     if len(sys.argv) != 4:
-        print("Usage: calc.py <add> <num1> <num2>")
+        print("Usage: calc.py <add|sub> <num1> <num2>")
         sys.exit(1)
     op = sys.argv[1]
-    if op != "add":
-        print(f"Unknown operation: {op}")
-        sys.exit(1)
     a = int(sys.argv[2])
     b = int(sys.argv[3])
-    print(add(a, b))
+    if op == "add":
+        print(add(a, b))
+    elif op == "sub":
+        print(subtract(a, b))
+    else:
+        print(f"Unknown operation: {op}")
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/test_calc.py
+++ b/test_calc.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """Tests for calc.py."""
-from calc import add
+from calc import add, subtract
 
 
 def test_add_positive():
@@ -15,8 +15,23 @@ def test_add_negative():
     assert add(-1, 1) == 0
 
 
+def test_subtract_positive():
+    assert subtract(5, 3) == 2
+
+
+def test_subtract_zero():
+    assert subtract(5, 0) == 5
+
+
+def test_subtract_negative():
+    assert subtract(3, 5) == -2
+
+
 if __name__ == "__main__":
     test_add_positive()
     test_add_zero()
     test_add_negative()
+    test_subtract_positive()
+    test_subtract_zero()
+    test_subtract_negative()
     print("All tests passed!")


### PR DESCRIPTION
## Summary
- Add `subtract(a, b)` function to calc.py
- CLI accepts `sub` as operation: `calc.py sub 5 3` prints `2`
- Add tests for subtract in test_calc.py

## Test plan
- [x] `python3 calc.py sub 5 3` prints `2`
- [x] `python3 calc.py add 2 3` prints `5` (existing functionality still works)
- [x] `python3 test_calc.py` → "All tests passed!"

🤖 Generated with [Claude Code](https://claude.com/claude-code)