### PR TITLE
Fix negative number argument parsing in calc.py

### DIFF
--- a/calc.py
+++ b/calc.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 """Minimal calculator CLI for AgentFlow smoke test."""
+import argparse
 import sys
 
 
@@ -7,17 +8,34 @@ def add(a, b):
     return a + b
 
 
+def parse_args():
+    """Parse command line arguments, handling negative numbers correctly."""
+    parser = argparse.ArgumentParser(
+        description="Minimal calculator CLI",
+        usage="calc.py add <num1> <num2>",
+    )
+    parser.add_argument(
+        "operation",
+        choices=["add"],
+        help="Operation to perform (currently only 'add' supported)",
+    )
+    parser.add_argument(
+        "num1",
+        type=int,
+        help="First number",
+    )
+    parser.add_argument(
+        "num2",
+        type=int,
+        help="Second number",
+    )
+    return parser.parse_args()
+
+
 def main():
-    if len(sys.argv) != 4:
-        print("Usage: calc.py <add> <num1> <num2>")
-        sys.exit(1)
-    op = sys.argv[1]
-    if op != "add":
-        print(f"Unknown operation: {op}")
-        sys.exit(1)
-    a = int(sys.argv[2])
-    b = int(sys.argv[3])
-    print(add(a, b))
+    args = parse_args()
+    if args.operation == "add":
+        print(add(args.num1, args.num2))
 
 
 if __name__ == "__main__":

--- a/test_calc.py
+++ b/test_calc.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 """Tests for calc.py."""
+import subprocess
+import sys
 from calc import add
 
 
@@ -15,8 +17,85 @@ def test_add_negative():
     assert add(-1, 1) == 0
 
 
+def test_add_two_negatives():
+    """Test adding two negative numbers."""
+    assert add(-5, -3) == -8
+
+
+def test_add_negative_positive():
+    """Test adding negative and positive number."""
+    assert add(-1, 2) == 1
+    assert add(5, -3) == 2
+
+
+def test_add_large_negatives():
+    """Test with large negative numbers."""
+    assert add(-1000, -2000) == -3000
+    assert add(-999999, 1) == -999998
+
+
+# CLI Integration Tests
+def run_cli(args):
+    """Helper to run calc.py as a subprocess."""
+    result = subprocess.run(
+        [sys.executable, "calc.py"] + args,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip(), result.returncode
+
+
+def test_cli_add_positive():
+    """Test CLI with positive numbers."""
+    output, code = run_cli(["add", "5", "3"])
+    assert code == 0
+    assert output == "8"
+
+
+def test_cli_add_single_negative():
+    """Test CLI with one negative number: calc.py add -1 2"""
+    output, code = run_cli(["add", "-1", "2"])
+    assert code == 0
+    assert output == "1"
+
+
+def test_cli_add_two_negatives():
+    """Test CLI with two negative numbers: calc.py add -5 -3"""
+    output, code = run_cli(["add", "-5", "-3"])
+    assert code == 0
+    assert output == "-8"
+
+
+def test_cli_add_negative_result():
+    """Test CLI that produces negative result."""
+    output, code = run_cli(["add", "-10", "-20"])
+    assert code == 0
+    assert output == "-30"
+
+
+def test_cli_invalid_operation():
+    """Test CLI with invalid operation."""
+    output, code = run_cli(["subtract", "5", "3"])
+    assert code != 0
+
+
+def test_cli_missing_args():
+    """Test CLI with missing arguments."""
+    output, code = run_cli(["add"])
+    assert code != 0
+
+
 if __name__ == "__main__":
     test_add_positive()
     test_add_zero()
     test_add_negative()
+    test_add_two_negatives()
+    test_add_negative_positive()
+    test_add_large_negatives()
+    test_cli_add_positive()
+    test_cli_add_single_negative()
+    test_cli_add_two_negatives()
+    test_cli_add_negative_result()
+    test_cli_invalid_operation()
+    test_cli_missing_args()
     print("All tests passed!")


### PR DESCRIPTION
## Summary

- Fixed negative number argument parsing in `calc.py` CLI tool by replacing manual `sys.argv` parsing with Python's `argparse` module
- Added comprehensive test coverage for negative number scenarios (9 new test cases)
- All 12 tests pass (3 original + 9 new)

## Problem

The `calc.py` CLI tool had a bug where negative number arguments were not handled correctly. Commands like:
- `calc.py add -1 2` should print `1`
- `calc.py add -5 -3` should print `-8`

These scenarios are now working correctly.

## Solution

Replaced manual `sys.argv` parsing with Python's `argparse` module, which properly handles negative number arguments without requiring any special flags or workarounds.

## Test Coverage

### Unit Tests Added
- `test_add_two_negatives()` - test adding two negative numbers
- `test_add_negative_positive()` - test mixed sign operations
- `test_add_large_negatives()` - test edge cases with large negatives

### CLI Integration Tests Added
- `test_cli_add_positive()` - CLI with positive numbers
- `test_cli_add_single_negative()` - CLI with one negative
- `test_cli_add_two_negatives()` - CLI with two negatives
- `test_cli_add_negative_result()` - CLI producing negative result
- `test_cli_invalid_operation()` - CLI error handling
- `test_cli_missing_args()` - CLI missing arguments

## Test plan

- [x] `python3 calc.py add -1 2` prints `1`
- [x] `python3 calc.py add -5 -3` prints `-8`
- [x] `python3 calc.py add 5 3` prints `8` (existing behavior preserved)
- [x] All 12 tests pass with `python3 test_calc.py`
- [x] CI workflow compatibility verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)